### PR TITLE
form-validation moved to validate.js and hardcode removed

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 		<div class="popup__container">
 			<button type="button" class="popup__close-button"><img class="popup__img-close-button" src="./images/close-icon.svg" alt="Х"></button>
 			<h2 class="popup__title">Редактировать профиль</h2>
-			<form name="edit-profile" novalidate>
+			<form name="edit-profile" class="popup__form" novalidate>
 				<fieldset class="popup__edit-form-container">
 					
 					<lable class="popup__form-field">
@@ -62,7 +62,7 @@
 		<div class="popup__container">
 			<button type="button" class="popup__close-button"><img class="popup__img-close-button" src="./images/close-icon.svg" alt="Х"></button>
 			<h2 class="popup__title">Новое место</h2>
-			<form name="add-new-publication" novalidate>
+			<form name="add-new-publication" class="popup__form" novalidate>
 				<fieldset class="popup__edit-form-container">
 					
 					<lable class="popup__form-field">
@@ -102,5 +102,6 @@
 	</template>
 	
 	<script src="./scripts/index.js"></script>
+	<script src="./scripts/validate.js"></script>
 </body>
 </html>

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -1,0 +1,61 @@
+function enableValidation(config) {
+  const formArr = Array.from(document.querySelectorAll(config.formElement));
+  formArr.forEach(iForm => {
+    setInputListeners(iForm, config);
+    iForm.addEventListener('submit', function (evt) {
+      evt.preventDefault();
+    });
+  });
+}
+
+function setInputListeners(form, config) {
+  const inputArr = Array.from(form.querySelectorAll(config.inputElement));
+  const submitButtonElem = form.querySelector(config.buttonElement);
+
+  toggleButtonState(submitButtonElem, form.checkValidity(), config);
+
+  inputArr.forEach(iInput => {
+    iInput.addEventListener('input', () => {
+      toggleInputErrorMsg(form, iInput, config);
+      toggleButtonState(submitButtonElem, form.checkValidity(), config);
+    })
+  });
+}
+
+function toggleInputErrorMsg(form, inputElement, config) {
+  if (inputElement.validity.valid) {
+    hideInputError(form, inputElement, config);
+  } else {
+    showInputError(form, inputElement, config);
+  };
+};
+
+function toggleButtonState(button, isFormValid, config) {
+  if (isFormValid) {
+    button.classList.remove(config.inactiveButtonClass);
+    button.removeAttribute('disabled');
+  } else {
+    button.classList.add(config.inactiveButtonClass);
+    button.setAttribute('disabled', true);
+
+  }
+};
+
+function showInputError(form, inputElement, config) {
+  // errorMsg is a span element with unic class name which mathes inputElement.id + "-error".
+  const errorMsg = form.querySelector(`.${inputElement.id}-error`);
+  errorMsg.classList.add(config.errorClass);
+  errorMsg.textContent = inputElement.validationMessage;
+  inputElement.classList.add(config.inputErrorClass);
+}
+
+function hideInputError(form, inputElement, config) {
+  // errorMsg is a span element with unic class name which mathes inputElement.id + "-error".
+  const errorMsg = form.querySelector(`.${inputElement.id}-error`);
+  errorMsg.classList.remove(config.errorClass);
+  errorMsg.textContent = '';
+  inputElement.classList.remove(config.inputErrorClass);
+}
+
+
+enableValidation(validationConfig);


### PR DESCRIPTION
- все функции валидации по чек-листу и заданию должны быть в файле validate.js
- по заданию функция enableValidation запускает всю валидацию
- Все строки-селекторы для валидации нужно брать только из объекта валидации, который передается в вызов каждой функции, начиная с enableValidation(settings), далее передается в setEventListeners(formElement, settings) и так далее. Скрин из задания https://disk.yandex.ru/i/hGFUIgkq8K3VVw . Это делается для того, чтобы можно было одним движением изменить селекторы в одном месте, а не искать их по всему коду, изменяя каждую строку-селектор. И это еще нужно для повышения независимости каждой функции от внешних данных
- в универсальной валидации не должно быть хардкода проверки под конкретные попапы, формы и кнопки.
- Весь код validate.js есть у Вас в тренажере. Нужно было просто его скопировать оттуда. Единственное отличие в том, что все селекторы нужно брать уже только из вызова каждой функции.
- Очищать форму и деактивировать кнопку нужно только после сабмита карточки. Просто при закрытиях (открытиях) не нужно этого делать, чтобы пользователю не нужно было печатать опять текст в инпутах, если он закрыл форму нечаянно